### PR TITLE
Feature: Reworked presence notifications

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,48 @@
+The storpool-presence interface format
+======================================
+
+JSON message format
+-------------------
+
+    {
+      "presence": {
+        "<service-name>": {
+          "<juju-node-id>": "<storpool-our-id>",
+          "<juju-node-id>": "<storpool-our-id>"
+        },
+        "<service-name>": {
+          "<juju-node-id>": "<storpool-our-id>",
+          "<juju-node-id>": "<storpool-our-id>"
+        },
+      "storpool_version": "<version of the StorPool package in the PPA>",
+      "storpool_openstack_version": "<version of the StorPool OpenStack integration package in the PPA>",
+      "storpool_conf": "<multiline contents of the /etc/storpool.conf file>"
+    }
+
+Fields description
+------------------
+
+- `service-name`: the type of the charm that is announcing its presence,
+   e.g. "block" or "cinder".
+
+- `juju-node-id`: the machine ID or the LXC ID that the service unit is
+   running on, e.g. "0" or "1/lxd/2".
+
+- `storpool-our-id`: the StorPool `SP_OURID` client ID used by this unit;
+   the `storpool-block` charm determines its value from the `storpool_conf`
+   setting, and the `cinder-storpool` charm uses the same value as
+   the `storpool-block` unit running on bare metal on the node that hosts
+   the `cinder-storpool` unit's container.  Thus, if `storpool-block` has
+   announced e.g. `SP_OURID` "3" on node "0", the `cinder-storpool` unit
+   running in the "0/lxd/2" container will use "3" as its own ID.
+
+- `storpool_version`: the version number (or rather, string) of
+   the `storpool-common`, `storpool-config`, et al packages that will be
+   installed from the StorPool PPA.
+
+- `storpool_openstack_version`: the version number (or rather, string) of
+   the `storpool-openstack-integration` package that will be installed from
+   the StorPool PPA.
+
+- `storpool_conf`: the contents of the `/etc/storpool.conf` file that
+   the units will install for the StorPool services and Python bindings.

--- a/provides.py
+++ b/provides.py
@@ -6,6 +6,7 @@ from charms import reactive
 from charmhelpers.core import unitdata
 
 from spcharms import kvdata
+from spcharms import service_hook
 from spcharms import utils as sputils
 
 
@@ -23,43 +24,17 @@ class StorPoolPresenceProvides(reactive.RelationBase):
     scope = reactive.scopes.GLOBAL
 
     @reactive.hook('{provides:storpool-presence}-relation-{joined,changed}')
-    def changed_new(self):
+    def changed(self):
         """
-        Somebody new came in, announce our presence to them if able.
+        Somebody came in or gave us new data.
         """
-        self.changed(True)
+        rdebug('storpool-presence/changed invoked')
+        service_hook.handle_remote_presence(self, rdebug=rdebug)
 
-    @reactive.hook('{provides:storpool-presence}-relation-{joined,changed}')
-    def changed_current(self):
+    @reactive.hook('{provides:storpool-presence}-relation-{departed,broken}')
+    def broken(self):
         """
-        Somebody we already know... but still, announce, maybe?
+        Let it go...
         """
-        self.changed(False)
-
-    def changed(self, joined):
-        """
-        Let the other layers know that another charm wants to receive
-        notifications from us.
-        """
-        rdebug('relation-joined/changed, setting the notify state to '
-               'kick something off')
-        self.set_state('{relation_name}.notify')
-        if joined:
-            self.set_state('{relation_name}.notify-joined')
-
-        conv = self.conversation()
-        mach_id = conv.get_remote('cinder_machine_id')
-        if mach_id is not None:
-            rdebug('- got a Cinder machine id: {cid}'.format(cid=mach_id))
-            parts = mach_id.split('/')
-            if len(parts) == 3 and parts[1] == 'lxd':
-                rdebug('- and it is a container...')
-                if parts[0] == sputils.get_machine_id():
-                    rdebug('- and it is ours!')
-                    unitdata.kv().set(kvdata.KEY_LXD_NAME, mach_id)
-                    self.set_state('{relation_name}.process-lxd-name')
-                else:
-                    rdebug('- but it is not ours ({mid} vs {oid})'
-                           .format(mid=mach_id, oid=sputils.get_machine_id()))
-            else:
-                rdebug('- but it is not a container')
+        rdebug('storpool-presence/departed invoked')
+        self.remove_state('{relation_name}.notify')

--- a/provides.py
+++ b/provides.py
@@ -5,7 +5,6 @@ charm's units, esp. the unit running on the local node.
 from charms import reactive
 from charmhelpers.core import unitdata
 
-from spcharms import kvdata
 from spcharms import service_hook
 from spcharms import utils as sputils
 

--- a/requires.py
+++ b/requires.py
@@ -33,7 +33,7 @@ class StorPoolPresenceRequires(reactive.RelationBase):
         service_hook.handle_remote_presence(self, rdebug=rdebug)
 
     @reactive.hook('{requires:storpool-presence}-relation-{departed,broken}')
-    def changed(self):
+    def broken(self):
         """
         Remove the "we are here" state.
         """

--- a/requires.py
+++ b/requires.py
@@ -6,14 +6,11 @@ import json
 import platform
 
 from charms import reactive
+from charmhelpers.core import unitdata
 
+from spcharms import kvdata
+from spcharms import service_hook
 from spcharms import utils as sputils
-
-STORPOOL_CONF_KEYS = (
-    'storpool_conf',
-    'storpool_version',
-    'storpool_openstack_version',
-)
 
 def rdebug(s):
     """
@@ -34,48 +31,13 @@ class StorPoolPresenceRequires(reactive.RelationBase):
         Handle a notification and set the "*.configure" state if the unit
         running on the local node has been set up.
         """
-        rdebug('relation-joined/changed invoked')
-        conv = self.conversation()
-        spconf = conv.get_remote('storpool_presence')
-        conv.set_local('storpool_presence', None)
-        reset = False
-        if spconf is None:
-            rdebug('no presence data yet')
-        else:
-            rdebug('whee, we got something from the {key} conversation, '
-                   'trying to deserialize it'.format(key=conv.key))
-            try:
-                conf = json.loads(spconf)
-                rdebug('got something: type {t}, dict keys: {k}'
-                       .format(t=type(conf).__name__,
-                               k=sorted(conf.keys()) if isinstance(conf, dict)
-                               else []))
-                if not isinstance(conf, dict):
-                    rdebug('well, it is not a dictionary, is it?')
-                    return
-                presence = conf.get('presence', None)
-                if not isinstance(presence, dict):
-                    rdebug('no presence data, just {keys}'
-                        .format(keys=','.join(sorted(conf.keys()))))
-                    return
-                rdebug('configured nodes: {nodes}'
-                       .format(nodes=','.join(sorted(presence.keys()))))
-                conv.set_local('storpool_presence', conf)
-                reset = True
-                
-                # Let them know we're here.
-                conv.set_remote('cinder_machine_id', sputils.get_machine_id())
+        rdebug('storpool-presence relation-joined/changed invoked')
+        service_hook.handle_remote_presence(self, rdebug=rdebug)
 
-                for key in STORPOOL_CONF_KEYS:
-                    data = conf.get(key, None)
-                    if data is None or data == '':
-                        rdebug('- {key} not supplied yet'.format(key=key))
-                        return
-                if presence.get(sputils.get_parent_node(), False):
-                    rdebug('our node seems to be configured!')
-                    self.set_state('{relation_name}.configure')
-            except Exception as e:
-                rdebug('oof, could not parse the presence data passed down '
-                       'the hook: {e}'.format(e=e))
-                if reset:
-                    conv.set_local('storpool_presence', None)
+    @reactive.hook('{requires:storpool-presence}-relation-{departed,broken}')
+    def changed(self):
+        """
+        Remove the "we are here" state.
+        """
+        rdebug('storpool-presence relation-departed/broken invoked')
+        self.remove_state('{relation_name}.notify')

--- a/requires.py
+++ b/requires.py
@@ -6,9 +6,7 @@ import json
 import platform
 
 from charms import reactive
-from charmhelpers.core import unitdata
 
-from spcharms import kvdata
 from spcharms import service_hook
 from spcharms import utils as sputils
 

--- a/unit_tests/lib/spcharms/__init__.py
+++ b/unit_tests/lib/spcharms/__init__.py
@@ -3,10 +3,7 @@
 import mock
 
 utils = mock.Mock()
-utils.MACHINE_ID = '42'
-utils.PARENT_NODE = '42'
-utils.get_machine_id.return_value = utils.MACHINE_ID
-utils.get_parent_node.return_value = utils.PARENT_NODE
+utils.rdebug = mock.Mock()
 
-kvdata = mock.Mock()
-kvdata.KEY_LXD_NAME = 'storpool-openstack-integration.lxd-name'
+service_hook = mock.Mock()
+service_hook.handle_remote_presence = mock.Mock()

--- a/unit_tests/test_storpool_presence.py
+++ b/unit_tests/test_storpool_presence.py
@@ -50,7 +50,6 @@ class TestStorPoolPresence(unittest.TestCase):
         """
         Test the data exchanged by the provides or requires interface.
         """
-        obj = testee_provides.StorPoolPresenceProvides('storpool-presence:42')
         obj.remove_state = mock.Mock()
         call_c = self.get_call_count(obj)
 

--- a/unit_tests/test_storpool_presence.py
+++ b/unit_tests/test_storpool_presence.py
@@ -172,7 +172,9 @@ class TestStorPoolPresence(unittest.TestCase):
         # And finally, a dictionary with everything in it!
         check_wonderful({
             'presence': {
-                sp_node: True,
+                'block': {
+                    sp_node: True,
+                },
             },
             'storpool_conf': 'whee',
             'storpool_version': '16.02',

--- a/unit_tests/test_storpool_presence.py
+++ b/unit_tests/test_storpool_presence.py
@@ -8,10 +8,7 @@ import os
 import sys
 import unittest
 
-import json
 import mock
-
-from charms import reactive
 
 root_path = os.path.realpath('.')
 if root_path not in sys.path:
@@ -21,6 +18,7 @@ lib_path = os.path.realpath('unit_tests/lib')
 if lib_path not in sys.path:
     sys.path.insert(0, lib_path)
 
+from spcharms import service_hook
 from spcharms import utils as sputils
 
 import provides as testee_provides
@@ -28,155 +26,56 @@ import requires as testee_requires
 
 
 class TestStorPoolPresence(unittest.TestCase):
-    """
-    Test the data exchanged by the storpool-presence interface.
-    """
-    @mock.patch('provides.StorPoolPresenceProvides.set_state')
-    def test_provides(self, set_state):
+    def get_call_count(self, obj):
         """
-        Test that the provider interface sets a reactive state.
+        Fetch the current call count of the tools used.
+        """
+        return {
+            'rdebug': sputils.rdebug.call_count,
+            'handle': service_hook.handle_remote_presence.call_count,
+            'remove': obj.remove_state.call_count,
+        }
+
+    def check_update_call_count(self, obj, ref, delta):
+        """
+        Fetch the current call count and check that the delta is
+        the same as the expected one.
+        """
+        current = self.get_call_count(obj)
+        for (k, v) in delta.items():
+            ref[k] += v
+        self.assertEqual(current, ref)
+
+    def do_test(self, obj):
+        """
+        Test the data exchanged by the provides or requires interface.
         """
         obj = testee_provides.StorPoolPresenceProvides('storpool-presence:42')
-        obj.changed(False)
-        set_state.assert_called_once_with('{relation_name}.notify')
+        obj.remove_state = mock.Mock()
+        call_c = self.get_call_count(obj)
 
-        # That's all, folks!
+        obj.changed()
+        self.check_update_call_count(obj, call_c, {
+            'rdebug': 1,
+            'handle': 1,
+        })
 
-    @mock.patch('requires.StorPoolPresenceRequires.set_state')
-    @mock.patch('requires.StorPoolPresenceRequires.conversation')
-    def test_requires(self, req_conv, set_state):
+        obj.broken()
+        self.check_update_call_count(obj, call_c, {
+            'rdebug': 1,
+            'remove': 1,
+        })
+
+    def test_provides(self):
         """
-        Test that the requires interface tries to exchange data.
+        Test the data exchanged by the provides interface.
         """
-        sp_node = sputils.MACHINE_ID
+        obj = testee_provides.StorPoolPresenceProvides('storpool-presence:42')
+        self.do_test(obj)
 
+    def test_requires(self):
+        """
+        Test the data exchanged by the provides interface.
+        """
         obj = testee_requires.StorPoolPresenceRequires('storpool-presence:42')
-
-        def set_local_state(name, value):
-            """
-            Record all the invocations of conv.set_state() by the charm.
-            """
-            self.local_state.append((name, value))
-
-        conv = mock.MagicMock(spec=reactive.relations.Conversation)
-        conv.set_local.side_effect = set_local_state
-        req_conv.return_value = conv
-
-        self.loop_index = 0
-        self.good_index = 0
-
-        def check_something(supplied, expected, good, state_inc):
-            """
-            Invoke the "relationship changed" handler, passing the specified
-            data as if it has arrived from the remote peer.
-            """
-            self.loop_index += 1
-            if good:
-                self.good_index += 1
-            conv.get_remote.return_value = supplied
-            self.local_state = []
-            state_count = set_state.call_count
-
-            obj.changed()
-
-            self.assertEquals(self.loop_index, conv.get_remote.call_count)
-            self.assertEquals(self.loop_index + self.good_index,
-                              conv.set_local.call_count)
-            if expected is None:
-                self.assertEquals([('storpool_presence', expected)],
-                                  self.local_state)
-            else:
-                self.assertEquals([
-                    ('storpool_presence', None),
-                    ('storpool_presence', expected),
-                ], self.local_state)
-            self.assertEquals(state_count + state_inc, set_state.call_count)
-
-        def check_bad(spconf):
-            """
-            Check that missing or invalid remote configuration does not
-            actually trigger any local events.
-            """
-            check_something(spconf, None, False, 0)
-
-        def check_half_bad(spconf):
-            """
-            Check that missing StorPool keys in the received configuration
-            do not actually trigger any local events.
-            """
-            check_something(json.dumps(spconf), None, False, 0)
-
-        def check_good(spdict):
-            """
-            Check that a well-formed remote configuration that does not have
-            presence information about our own Juju node still does not
-            trigger any local events, but is stored properly.
-            """
-            check_something(json.dumps(spdict), spdict, True, 0)
-
-        def check_wonderful(spdict):
-            """
-            Check that a well-formed remote configuration that has our node in
-            it goes the whole way.
-            """
-            check_something(json.dumps(spdict), spdict, True, 1)
-
-        # No configuration at all supplied
-        check_bad(None)
-
-        # Invalid JSON encoding of the configuration
-        check_bad('{[(')
-
-        # Not a JSON object
-        check_bad('[5]')
-
-        # An empty dictionary (no "presence" sub-dictionary)
-        check_half_bad({})
-
-        # An empty presence dictionary
-        check_good({'presence': {}})
-
-        # A dictionary without us in it
-        check_good({
-            'presence': {
-                "invalid node name": True,
-                "some other node": False
-            },
-        })
-
-        # A dictionary with us in it, but with a false value
-        check_good({
-            'presence': {
-                sp_node: False,
-            },
-        })
-
-        # A dictionary with us really in it...
-        check_good({
-            'presence': {
-                sp_node: True,
-            },
-        })
-
-        # A dictionary with us really in it...
-        # ...and still no other data
-        check_good({
-            'presence': {
-                sp_node: True,
-            },
-            'storpool_conf': '',
-            'storpool_version': '',
-            'storpool_openstack_version': '',
-        })
-
-        # And finally, a dictionary with everything in it!
-        check_wonderful({
-            'presence': {
-                'block': {
-                    sp_node: True,
-                },
-            },
-            'storpool_conf': 'whee',
-            'storpool_version': '16.02',
-            'storpool_openstack_version': '0.1.0',
-        })
+        self.do_test(obj)


### PR DESCRIPTION
Rework the way the StorPool charms (cinder-storpool and storpool-block) notify their own peers and the other charm about the readiness of the units on specific machines and with specific StorPool IDs.